### PR TITLE
Update build and publish workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      
-      # TODO: #2: add at a later time
-      # - name: White source scan
-      #   uses: mercari/Whitesource-Scan-Action@v1.0.0
-      #   with:
-      #     wssUrl: https://saas.whitesourcesoftware.com/agent?ctxId=gs5cnna7eyzxsuq94jficzk091k4aphvv8rhgut5gkw8i
-      #     apiKey: ${{ secrets.WSS_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,16 @@ jobs:
         with: 
           node-version: '16'
       
-      - uses: JS-DevTools/npm-publish@v1
+      - name: Install packages
+        run: npm install
+      
+      - name: Check formatting
+        run: npm run check-formatting
+
+      - name: Run unit tests and generate report
+        run: npm run test:ci
+
+      - name: Publish package
+        uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to React Async Renderer
+
+## Publishing
+
+1. Create a new branch with change log updates and a version bump under the `release/` namespace (e.g. `release/v1.2.1`).
+2. Create a pull request and merge that new branch into the `main` branch.
+3. [Publish a new Github release](https://docs.github.com/en/enterprise-cloud@latest/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) with a new release tag off of the merge commit of your release. Use the format `v<package.json version number>`, e.g. v1.2.1.
+4. Use the GitHub tool to generate the release notes.
+5. Rename "Full Changelog" to "Commit Changelog".
+6. On a new line, add "**Full Changelog**: `https://github.com/MFB-Technologies-Inc/react-async-renderer/blob/<new tag>/CHANGELOG.md`", replacing `<new tag>` with the tag for this release.
+
+> Publishing a new Github release will trigger the publish Github action, which publishes the new release to NPM.

--- a/README.md
+++ b/README.md
@@ -86,18 +86,6 @@ These other utility functions can be used to simplify the logic around `createAs
 - `getCascadedAsyncState`: Reduces a chain of asynchronous request objects down one asynchronous request object.
 - `getOptimisticAsyncLoadState`: Converts its arguments into an optimistic asynchronous request object such that if the arguments indicate a pending asynchronous request and a fulfilled asynchronous request, then the result is a fulfilled asynchronous request object.
 
-## Publishing
-
-1. Create a new branch with change log updates and a version bump.
-2. Create a pull request and merge that new branch into the `main` branch.
-3. [Publish a new Github release](https://docs.github.com/en/enterprise-cloud@latest/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) with a new release tag off of the `main` branch. Use the format `v<package.json version number>`, e.g. v1.2.1.
-
-   > Publishing a new Github release will trigger a Github action to publish the new release to NPM.
-
-4. Use the GitHub tool to generate the release notes.
-5. Rename "Full Changelog" to "Commit Changelog"
-6. On a new line, add "**Full Changelog**: `https://github.com/MFB-Technologies-Inc/react-async-renderer/blob/<new tag>/CHANGELOG.md`", replacing `<new tag>` with the tag for this release.
-
 ## Changelog
 
 [Changelog](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ These other utility functions can be used to simplify the logic around `createAs
 ## Publishing
 
 1. Create a new branch with change log updates and a version bump.
-2. Create and merge that new branch into the `main` branch.
-3. [Publish a new Github release](https://docs.github.com/en/enterprise-cloud@latest/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) with a new release tag off of the `main` branch.
+2. Create a pull request and merge that new branch into the `main` branch.
+3. [Publish a new Github release](https://docs.github.com/en/enterprise-cloud@latest/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) with a new release tag off of the `main` branch. Use the format `v<package.json version number>`, e.g. v1.2.1.
 
-> The release tag should be in the format `v<package.json version number>` (e.g. v1.2.1).
+   > Publishing a new Github release will trigger a Github action to publish the new release to NPM.
 
-> Publishing a new Github release will trigger a Github action to publish the new release to NPM.
+4. Use the GitHub tool to generate the release notes.
+5. Rename "Full Changelog" to "Commit Changelog"
+6. On a new line, add "**Full Changelog**: `https://github.com/MFB-Technologies-Inc/react-async-renderer/blob/<new tag>/CHANGELOG.md`", replacing `<new tag>` with the tag for this release.
 
 ## Changelog
 


### PR DESCRIPTION
- removed the white source step from the build job because we now have the Mend Bolt integration in GitHub that will [conditionally auto scan the source](https://whitesource.atlassian.net/wiki/spaces/WD/pages/594641301/Bolt+for+GitHub+-+Triggering+a+New+Scan). 
- setup a [merge policy](https://whitesource.atlassian.net/wiki/spaces/WD/pages/556007950/Mend+Bolt+for+GitHub#Prerequisite-for-the-Merge-Policy%3A-Add-a-Branch-Protection-Rule) for the `main` branch that [requires a security scan](https://github.com/MFB-Technologies-Inc/react-async-renderer/settings/branches).
- init contributing doc with info on how to publish this package
- finish github publish action
