### PR TITLE
fix publish workflow by fixing package access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: "public"


### PR DESCRIPTION
By default scoped packages ("@mfbtech" is our scope) are published as private packages. Added the `access` argument to specify that the package should be published publicly. 

https://docs.npmjs.com/about-scopes
https://github.com/JS-DevTools/npm-publish#input-parameters