### PR TITLE
Bugfix/47 ignore example app deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # version and security updates for the root application
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # version and security updates for the example application
+  - package-ecosystem: "npm"
+    directory: "/example-app"
+    schedule:
+      interval: "weekly"
+    # TODO: can this be removed?
+    # using allow because ignore's docs say "Use with the allow option to define exactly which 
+    # dependencies to maintain for a package ecosystem"
+    # allow:
+    #   - dependency-name: "mfb-match-no-deps"
+    ignore:
+      - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,5 @@ updates:
     directory: "/example-app"
     schedule:
       interval: "weekly"
-    # TODO: can this be removed?
-    # using allow because ignore's docs say "Use with the allow option to define exactly which 
-    # dependencies to maintain for a package ecosystem"
-    # allow:
-    #   - dependency-name: "mfb-match-no-deps"
     ignore:
       - dependency-name: "*"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "psioniq.psi-header",
     "dbaeumer.vscode-eslint",
     "ms-vsliveshare.vsliveshare",
-    "davidanson.vscode-markdownlint",
-    "github.vscode-github-actions"
+    "davidanson.vscode-markdownlint"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "psioniq.psi-header",
     "dbaeumer.vscode-eslint",
     "ms-vsliveshare.vsliveshare",
-    "davidanson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint",
+    "github.vscode-github-actions"
   ]
 }


### PR DESCRIPTION
attempt to tell dependabot to ignore the example app when scanning for security vulnerabilities and updates.